### PR TITLE
Add className as prop

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -6,7 +6,8 @@ var DateInput = React.createClass({
 
   getDefaultProps: function() {
     return {
-      dateFormat: 'YYYY-MM-DD'
+      dateFormat: 'YYYY-MM-DD',
+      className: "datepicker__input"
     };
   },
 
@@ -79,7 +80,7 @@ var DateInput = React.createClass({
       onKeyDown={this.handleKeyDown}
       onFocus={this.props.onFocus}
       onChange={this.handleChange}
-      className="datepicker__input"
+      className={this.props.className}
       placeholder={this.props.placeholderText}
       disabled={this.props.disabled} />;
   }


### PR DESCRIPTION
With default of "datepicker__input". I know there is a pull request, but it wasn't merged yet. Its an absolute showstopper that there is currently no way to define a class name. This seems like the most unobtrusive, non-breaking way.